### PR TITLE
Add missing import of assetUrl in fusion-plugin-font-loader-react Snippet

### DIFF
--- a/content/getting-started.md
+++ b/content/getting-started.md
@@ -135,6 +135,7 @@ import App from 'fusion-react';
 import Fonts, {
   FontLoaderReactConfigToken
 } from 'fusion-plugin-font-loader-react';
+import {assetUrl} from 'fusion-core';
 import root from './components/root';
 
 export default () => {


### PR DESCRIPTION
In getting started page, fusion-plugin-font-loader-react section, there is a missing import of assetUrl in fusion-plugin-font-loader-react Snippet.
Added it to make the snippet working