### PR TITLE
Add missing argument to ExamplePlugin's provider to access config dependency

### DIFF
--- a/content/creating-a-plugin.md
+++ b/content/creating-a-plugin.md
@@ -312,7 +312,7 @@ import {createPlugin, createToken} from 'fusion-core';
 export const ConfigToken = createToken('ConfigToken');
 export default createPlugin({
   deps: {config: ConfigToken},
-  provides() {
+  provides({config}) {
     return {
       greet() {
         return config; // returns 'hello'


### PR DESCRIPTION
In the code snippet to explain dependency injection in plugins
the provider function accessed `config` without being declared as a destructured argument.
Added it to fix the code snippet