### PR TITLE
Fix and remove .md extension from links

### DIFF
--- a/documentation/docs/getting-started/index.md
+++ b/documentation/docs/getting-started/index.md
@@ -20,7 +20,7 @@ Here are the features you'll find in Fusion.js:
 - plugins for error logging, security, etc.
 - bundle analysis tooling
 
-If you want to know how Fusion.js compares to similar projects, see the [framework comparison page](framework-comparison.md).
+If you want to know how Fusion.js compares to similar projects, see the [framework comparison page](/docs/getting-started/framework-comparison).
 
 ---
 
@@ -165,12 +165,12 @@ Here are some more in-depth sections covering various aspects of Fusion.js:
 #### Core concepts
 
 - [Universal rendering](/docs/guides/universal-rendering)
-- [Creating a plugin](/docs/guides/creating-a-plugin.md)
-  - [Tokens](/docs/guides/creating-a-plugin/tokens.md)
-  - [Dependencies](/docs/guides/creating-a-plugin/dependencies.md)
-  - [Creating endpoints](/docs/guides/creating-a-plugin/creating-endpoints.md)
-  - [Creating providers](/docs/guides/creating-a-plugin/creating-providers.md)
-  - [Modifying the HTML template](/docs/guides/creating-a-plugin/modifying-html-template.md)
+- [Creating a plugin](/docs/guides/creating-a-plugin)
+  - [Tokens](/docs/guides/creating-a-plugin/tokens)
+  - [Dependencies](/docs/guides/creating-a-plugin/dependencies)
+  - [Creating endpoints](/docs/guides/creating-a-plugin/creating-endpoints)
+  - [Creating providers](/docs/guides/creating-a-plugin/creating-providers)
+  - [Modifying the HTML template](/docs/guides/creating-a-plugin/modifying-html-template)
 
 #### Plugins
 

--- a/documentation/docs/guides/creating-a-plugin/creating-endpoints.md
+++ b/documentation/docs/guides/creating-a-plugin/creating-endpoints.md
@@ -4,7 +4,7 @@ Fusion.js provides an [RPC plugin](https://github.com/fusionjs/fusion-plugin-rpc
 
 Here we will implement an HTTP endpoint manually to better understand how Fusion.js middlewares work.
 
-The simplest way to write a Fusion.js plugin is a [middleware plugin](creating-a-plugin.md#middlewares):
+The simplest way to write a Fusion.js plugin is a [middleware plugin](creating-a-plugin#middlewares):
 
 ```js
 // src/plugins/example.js
@@ -39,7 +39,7 @@ export default createPlugin({
 });
 ```
 
-There's one issue left with the code above: Fusion.js code runs isomorphically by default, but we only want to run that code in the server. To do so, add a [code fence](universal-code.md):
+There's one issue left with the code above: Fusion.js code runs isomorphically by default, but we only want to run that code in the server. To do so, add a [code fence](/docs/guides/universal-rendering):
 
 ```js
 // src/plugins/example.js

--- a/documentation/docs/guides/creating-a-plugin/dependencies.md
+++ b/documentation/docs/guides/creating-a-plugin/dependencies.md
@@ -2,7 +2,7 @@
 
 The Fusion.js plugin architecture allows plugins to explicitly depend on other service plugins. This allows us to swap implementations of various subsystems, for example for testing, or to provide extended functionality.
 
-A [service plugin](creating-a-plugin.md#services) is a plugin that contains a service that exposes a programmatic API. The benefit of encapsulating a service into a plugin is that a plugin allows the service instance to be memoized on a per-request basis without polluting the middleware context, and the plugin can also encapsulate the colocation of all code needed to implement related [endpoints](creating-endpoints.md), [providers](creating-providers.md) and [HTML template modifications](modifying-html-template.md).
+A [service plugin](creating-a-plugin#services) is a plugin that contains a service that exposes a programmatic API. The benefit of encapsulating a service into a plugin is that a plugin allows the service instance to be memoized on a per-request basis without polluting the middleware context, and the plugin can also encapsulate the colocation of all code needed to implement related [endpoints](creating-endpoints), [providers](creating-providers) and [HTML template modifications](modifying-html-template).
 
 Let's see how we can depend on a service that gets instantiated per request:
 
@@ -41,7 +41,7 @@ export default createPlugin({
 
 The `Name` plugin simply saves the value in `?name=[value]` to a cookie session if that querystring value is defined.
 
-Notice that the `middleware` method of the `Name` plugin receives `{Session}` as an argument. This is the same `{Session}` that we passed to `app.register(SessionToken, JWTSession)` and it's [how Fusion.js plugins do dependency injection](creatinga-plugin.md#configuration).
+Notice that the `middleware` method of the `Name` plugin receives `{Session}` as an argument. This is the same `{Session}` that we passed to `app.register(SessionToken, JWTSession)` and it's [how Fusion.js plugins do dependency injection](creating-a-plugin#configuration).
 
 We then called `Session.from(ctx)`, which is how that plugin creates a memoized instance per request.
 

--- a/documentation/docs/guides/creating-a-plugin/tokens.md
+++ b/documentation/docs/guides/creating-a-plugin/tokens.md
@@ -1,6 +1,6 @@
 # Tokens
 
-Tokens are used by the Fusion.js [dependency injection](creating-a-plugin.md#dependency-injection) system to define the dependency tree of an application. Tokens are designed to bridge the gap between the type checking and runtime information. Your app may register your own Fusion.js plugin to a token to control behavior of your application or test.
+Tokens are used by the Fusion.js [dependency injection](creating-a-plugin#dependency-injection) system to define the dependency tree of an application. Tokens are designed to bridge the gap between the type checking and runtime information. Your app may register your own Fusion.js plugin to a token to control behavior of your application or test.
 
 ## Type safety
 

--- a/documentation/docs/guides/working-with-secrets.md
+++ b/documentation/docs/guides/working-with-secrets.md
@@ -21,7 +21,7 @@ export default () => {
 };
 ```
 
-Remember that typically we should only expose secrets in the server. In the example above, the `__NODE__ && process.env.SESSION_SECRET` expression [gets removed from the browser bundle](universal-code.md) via UglifyJS' dead code elimination.
+Remember that typically we should only expose secrets in the server. In the example above, the `__NODE__ && process.env.SESSION_SECRET` expression [gets removed from the browser bundle](universal-rendering) via UglifyJS' dead code elimination.
 
 # Secret rotation
 


### PR DESCRIPTION
Links with the .md extension work fine when it only references the page.
Other links containing anchors to a specific section of the page will
fail (i.e.
https://fusionjs.com/docs/guides/creating-a-plugin/creating-a-plugin.md#middlewares).