### PR TITLE
Use full path in links

### DIFF
--- a/documentation/docs/guides/creating-a-plugin/creating-endpoints.md
+++ b/documentation/docs/guides/creating-a-plugin/creating-endpoints.md
@@ -4,7 +4,7 @@ Fusion.js provides an [RPC plugin](https://github.com/fusionjs/fusion-plugin-rpc
 
 Here we will implement an HTTP endpoint manually to better understand how Fusion.js middlewares work.
 
-The simplest way to write a Fusion.js plugin is a [middleware plugin](../creating-a-plugin#middlewares):
+The simplest way to write a Fusion.js plugin is a [middleware plugin](/docs/guides/creating-a-plugin#middlewares):
 
 ```js
 // src/plugins/example.js

--- a/documentation/docs/guides/creating-a-plugin/tokens.md
+++ b/documentation/docs/guides/creating-a-plugin/tokens.md
@@ -1,6 +1,6 @@
 # Tokens
 
-Tokens are used by the Fusion.js [dependency injection](../creating-a-plugin#dependency-injection) system to define the dependency tree of an application. Tokens are designed to bridge the gap between the type checking and runtime information. Your app may register your own Fusion.js plugin to a token to control behavior of your application or test.
+Tokens are used by the Fusion.js [dependency injection](/docs/guides/creating-a-plugin#dependency-injection) system to define the dependency tree of an application. Tokens are designed to bridge the gap between the type checking and runtime information. Your app may register your own Fusion.js plugin to a token to control behavior of your application or test.
 
 ## Type safety
 


### PR DESCRIPTION
There is a bug with trailing forward slashes in the published documentation that can break links using relative paths. Use full paths in links for the time being.