### PR TITLE
Remove `yarn lint` from run-your-project.md

### DIFF
--- a/documentation/docs/getting-started/run-your-project.md
+++ b/documentation/docs/getting-started/run-your-project.md
@@ -107,11 +107,12 @@ Runs a bundle that was built via `yarn build`
 * `yarn start --dir=dir` - Specify the root directory for the application,
   relative to cwd. Defaults to `.`
 
+
+<!--
 #### `yarn lint`
 
 Runs eslint
 
-<!--
 #### `yarn profile`
 
 Opens source-map-explorer


### PR DESCRIPTION
There is no `lint` script present when a fusion project is generated, so it should not be listed in the documentation.