### PR TITLE
Add CTA module + tracking to home page

### DIFF
--- a/src/components/style-settings.js
+++ b/src/components/style-settings.js
@@ -8,6 +8,7 @@ export default {
   white120Color: '#999999',
   blackColor: '#000000',
   black90Color: '#041725',
+  blueColor: '#276EF1',
   fontFamily: `ff-clan-web-pro, "-apple-system", BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen,
     Ubuntu, Cantarell, "Fira Sans", "Droid Sans", "Helvetica Neue", "sans-serif"`,
 };

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -115,7 +115,7 @@ const CTALeftBox = styled('div', {
 });
 
 const CTARightBox = styled('div', {
-  backgroundColor: '#000000',
+  backgroundColor: 'black',
   color: '#33FF00',
   width: '50%',
   textAlign: 'left',

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -6,7 +6,7 @@ import peopleImg from '../images/person.svg';
 import alarm from '../images/alarm-clock.svg';
 import help from '../images/help.svg';
 import github from '../images/github.svg';
-import {white10Color} from '../components/style-settings';
+import {blueColor, white10Color} from '../components/style-settings';
 import startup from '../images/startup.svg';
 import strategy from '../images/strategy.svg';
 
@@ -14,8 +14,8 @@ const highlight = code =>
   Prism.highlight(code, Prism.languages.javascript, 'javascript');
 
 const HeroContainer = styled('div', {
-  width: '75%',
-  margin: '100px auto'
+  width: '80%',
+  margin: '100px auto 75px'
 });
 
 const FlexContainer = styled('div', ({styleProps = {}}) => ({
@@ -102,6 +102,60 @@ const Image = styled('img', {
   height: '150px',
 });
 
+const CTAContainer = styled('div', {
+  display: 'flex',
+  flexDirection: 'row',
+  marginTop: '50px',
+});
+
+const CTALeftBox = styled('div', {
+  backgroundColor: white10Color,
+  padding: '30px 20px',
+  width: '50%',
+});
+
+const CTARightBox = styled('div', {
+  backgroundColor: '#000000',
+  color: '#33FF00',
+  width: '50%',
+  textAlign: 'left',
+});
+
+const CTATitle = styled('h3', {
+  margin: 0,
+});
+
+const CTAPrimaryButton = styled(Link, {
+  ':hover': {
+    backgroundColor: 'black',
+    borderColor: 'black',
+    textDecoration: 'none',
+  },
+  backgroundColor: blueColor,
+  border: `1px solid ${blueColor}`,
+  color: 'white',
+  cursor: 'pointer',
+  display: 'inline-block',
+  marginRight: '20px',
+  minWidth: '140px',
+  padding: '10px 0px',
+});
+
+const CTASecondaryButton = styled('a', {
+  ':hover': {
+    borderColor: 'black',
+    color: 'black',
+    textDecoration: 'none',
+  },
+  backgroundColor: 'white',
+  border: `1px solid ${blueColor}`,
+  color: blueColor,
+  cursor: 'pointer',
+  display: 'inline-block',
+  minWidth: '140px',
+  padding: '10px 0px',
+});
+
 const Home = () => {
   return (
     <div>
@@ -112,11 +166,28 @@ const Home = () => {
           <p>
             Fusion.js gives you the developer experience you expect from a
             React/Redux setup and provides tools to take project quality to the
-            next level.<br />
-            <Link to="/docs/getting-started">
-              Let's get started &gt;
-            </Link>
+            next level.
           </p>
+          <CTAContainer>
+            <CTALeftBox>
+              <CTATitle>Try it out!</CTATitle>
+              <p>Get started building applications with Fusion.js in minutes.</p>
+              <CTAPrimaryButton to="/docs/getting-started">Quick Start</CTAPrimaryButton>
+              <CTASecondaryButton href="https://github.com/fusionjs" target="_blank">Github</CTASecondaryButton>
+            </CTALeftBox>
+            <CTARightBox>
+              <pre
+                // eslint-disable-next-line react/no-danger
+                dangerouslySetInnerHTML={{
+                  __html: `
+$ yarn create fusion-app my-fusion-app
+$ cd my-fusion-app
+$ yarn dev
+                `
+                }}
+              />
+            </CTARightBox>
+          </CTAContainer>
         </Description>
       </HeroContainer>
       <AltContainer>

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import {styled} from 'styletron-react';
 import Link from 'gatsby-link';
+import {OutboundLink} from 'gatsby-plugin-google-analytics';
 import Prism from 'prismjs';
 import peopleImg from '../images/person.svg';
 import alarm from '../images/alarm-clock.svg';
@@ -141,7 +142,7 @@ const CTAPrimaryButton = styled(Link, {
   padding: '10px 0px',
 });
 
-const CTASecondaryButton = styled('a', {
+const CTASecondaryButton = styled(OutboundLink, {
   ':hover': {
     borderColor: 'black',
     color: 'black',
@@ -155,6 +156,12 @@ const CTASecondaryButton = styled('a', {
   minWidth: '140px',
   padding: '10px 0px',
 });
+
+const trackQuickStart = () => {
+  if (window.ga) {
+    window.ga('send', 'event', 'click', 'home', 'quick_start');
+  }
+};
 
 const Home = () => {
   return (
@@ -172,7 +179,7 @@ const Home = () => {
             <CTALeftBox>
               <CTATitle>Try it out!</CTATitle>
               <p>Get started building applications with Fusion.js in minutes.</p>
-              <CTAPrimaryButton to="/docs/getting-started">Quick Start</CTAPrimaryButton>
+              <CTAPrimaryButton to="/docs/getting-started" onClick={trackQuickStart}>Quick Start</CTAPrimaryButton>
               <CTASecondaryButton href="https://github.com/fusionjs" target="_blank">Github</CTASecondaryButton>
             </CTALeftBox>
             <CTARightBox>

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -180,7 +180,7 @@ const Home = () => {
               <CTATitle>Try it out!</CTATitle>
               <p>Get started building applications with Fusion.js in minutes.</p>
               <CTAPrimaryButton to="/docs/getting-started" onClick={trackQuickStart}>Quick Start</CTAPrimaryButton>
-              <CTASecondaryButton href="https://github.com/fusionjs" target="_blank">Github</CTASecondaryButton>
+              <CTASecondaryButton href="https://github.com/fusionjs/fusion-core" target="_blank">Github</CTASecondaryButton>
             </CTALeftBox>
             <CTARightBox>
               <pre


### PR DESCRIPTION
Adds a module that shows how easy it is to get started with Fusion. This is similar to other CTA's in other open source frameworks that show in a minimal amount of lines how to install and run.

![image](https://user-images.githubusercontent.com/19541187/53065597-2a807d00-3481-11e9-9101-fbd9abecb022.png)

Also adds ga event tracking to track who clicks the quick start button as well as outbound link tracking so we can track who goes to Github.
