### PR TITLE
Track outbound links across entire site

### DIFF
--- a/plugins/gatsby-remark-transform-links/index.js
+++ b/plugins/gatsby-remark-transform-links/index.js
@@ -14,6 +14,15 @@ module.exports = ({markdownAST}) => {
     if (!reAbsoluteLink.test(node.url)) {
       node.url = node.url.replace(/\.md$/i, '');
     }
+    // If absolute link track outbound links
+    else {
+      if (!node.data) {
+        node.data = {};
+      }
+      node.data.hProperties = {
+        onclick: "return window.trackOutboundLink(this);",
+      };
+    }
     // update github's fusionjs links to docs to links to docs website
     if (node.url.indexOf(fusionjsLink) === 0) {
       const linkUrl = new URL(node.url);

--- a/src/components/footer.js
+++ b/src/components/footer.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import {styled} from 'styletron-react';
 import Link from 'gatsby-link';
+import {OutboundLink} from 'gatsby-plugin-google-analytics';
 import {PageWidth, FlexContainer, FlexItem} from '../layouts/styled-elements';
 
 const Footer = styled('footer', ({styleProps = {}}) => ({
@@ -12,7 +13,7 @@ const Footer = styled('footer', ({styleProps = {}}) => ({
   ...styleProps.overrides,
 }));
 
-const ExternalLink = styled('a', {
+const ExternalLink = styled(OutboundLink, {
   backgroundColor: 'transparent',
   color: 'inherit',
   textDecoration: 'none',

--- a/src/html.js
+++ b/src/html.js
@@ -75,12 +75,34 @@ module.exports = class HTML extends React.Component {
             dangerouslySetInnerHTML={{
               __html: `
               window.onload = () => {
-                window.docsearch({ 
-                  apiKey: '380d5368678eb99d4faa6ce5077c4827', 
-                  indexName: 'fusionjs', 
-                  inputSelector: '#search-field', 
-                  debug: false // Set debug to true if you want to inspect the dropdown 
+                window.docsearch({
+                  apiKey: '380d5368678eb99d4faa6ce5077c4827',
+                  indexName: 'fusionjs',
+                  inputSelector: '#search-field',
+                  debug: false // Set debug to true if you want to inspect the dropdown
                 });
+              };
+            `,
+            }}
+          />
+          <script
+            type="text/javascript"
+            dangerouslySetInnerHTML={{
+              __html: `
+              window.trackOutboundLink = (aTag) => {
+                if (window.ga && aTag.href) {
+                  window.ga('send', 'event', {
+                    eventCategory: 'Outbound Link',
+                    eventAction: 'click',
+                    eventLabel: aTag.href,
+                    transport: 'beacon',
+                    hitCallback: () => {
+                      document.location = aTag.href;
+                    }
+                  });
+                  return false;
+                }
+                return true;
               };
             `,
             }}

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -390,7 +390,7 @@ export const TeamService = createPlugin({
           <h4>GitHub</h4>
           <p>
             Have a question about Fusion or want to contribute? Check it out on{' '}
-            <a href="https://github.com/fusionjs">GitHub</a>.
+            <OutboundLink href="https://github.com/fusionjs">GitHub</OutboundLink>.
           </p>
         </FocusBlock>
       </FlexContainer>

--- a/src/pages/support/index.js
+++ b/src/pages/support/index.js
@@ -6,6 +6,7 @@ import webDevGroup from '../../images/web-dev-group.svg';
 import stack from '../../images/stack.svg';
 import bug from '../../images/bug.svg';
 import {white10Color} from '../../components/style-settings';
+import {OutboundLink} from 'gatsby-plugin-google-analytics';
 
 const FlexContainer = styled('div', ({styleProps = {}}) => ({
   display: 'flex',
@@ -89,9 +90,9 @@ const Component = () => {
           <h4>Stack Overflow</h4>
           <p>
             Ask your question and share knowledge on{' '}
-            <a href="https://stackoverflow.com" target="_blank">
+            <OutboundLink href="https://stackoverflow.com/search?q=fusionjs" target="_blank">
               Stack Overflow
-            </a>. We are working on getting a "fusion.js" tag created for this.
+            </OutboundLink>. We are working on getting a "fusion.js" tag created for this.
           </p>
         </FocusBlock>
         <FocusBlock>
@@ -104,12 +105,12 @@ const Component = () => {
           <h4>Slack</h4>
           <p>
             Join our{' '}
-            <a
+            <OutboundLink
               href="https://join.slack.com/t/fusionjs/shared_invite/enQtNDE1NjY2Mjk0OTMxLTg0NmZhY2FiZjQzZjU3ZTA4ODQ0NTNjNjhhYjVlNTk3NDQzMWJkOGFhNmU0Yzc1NjE0YmMxYjEwMTFlYjE2OWI"
               target="_blank"
             >
               Slack
-            </a>{' '}
+            </OutboundLink>{' '}
             to chat with Fusion.js core developers and the community.
           </p>
         </FocusBlock>
@@ -121,9 +122,9 @@ const Component = () => {
           <p>
             If you have found an bug or other issue in Fusion.js please file a
             bug report in one of our repos{' '}
-            <a href="https://github.com/fusionjs" target="_blank">
+            <OutboundLink href="https://github.com/fusionjs" target="_blank">
               https://github.com/fusionjs
-            </a>.
+            </OutboundLink>.
           </p>
         </FocusBlock>
       </FlexContainer>


### PR DESCRIPTION
1) Adds OutboundLink component to React pages to properly track outbound visits
2) Modifies the custom plugin that iterates through all markdown links and adds an `onclick` handler to them that will call a globally defined method to track outbound visits