### PR TITLE
Remove next steps from core concepts

### DIFF
--- a/documentation/docs/learn-fusion/core-concepts.md
+++ b/documentation/docs/learn-fusion/core-concepts.md
@@ -160,9 +160,3 @@ Yarn is a package manager for Node.js, similar to (and interchangeable with) NPM
 ### Zopfli
 
 A compression algorithm, compatible with gzip. Provides better compression rates than regular gzip. Fusion.js uses zopfli compression by default.
-
----
-
-### Next steps
-
-* [Framework Comparison](/docs/learn-fusion/framework-comparison)


### PR DESCRIPTION
This doc is shared with the internal site but the link it's pointing to doesn't exist internally.

I thought about just making that page available internally but reading it over it's a little information dense that someone internally doesn't really need to know.