### PR TITLE
Remove next steps from core concepts

### DIFF
--- a/documentation/docs/learn-fusion/core-concepts.md
+++ b/documentation/docs/learn-fusion/core-concepts.md
@@ -160,9 +160,3 @@ Yarn is a package manager for Node.js, similar to (and interchangeable with) NPM
 ### Zopfli
 
 A compression algorithm, compatible with gzip. Provides better compression rates than regular gzip. Fusion.js uses zopfli compression by default.
-
----
-
-### Next steps
-
-* [Framework Comparison](/docs/learn-fusion/framework-comparison)


### PR DESCRIPTION
Removes unneeded "Next Steps" from Core Concepts. This is still being shared internally and the navigation structure no longer matches so this prevents link breakage.