### PR TITLE
Add basic documentation on web workers

### DIFF
--- a/documentation/docs/references/web-workers.md
+++ b/documentation/docs/references/web-workers.md
@@ -1,0 +1,65 @@
+---
+title: "Web workers"
+path: /web-workers
+---
+
+# Web workers
+
+A web worker is a mechanism for running background tasks outside of the browser context. Heavy and resource consuming tasks can instead be moved to a background task so as to not block any UI threads in the main window. Communication is done through `postMessage` and `onmessage` handlers on the worker instance.
+
+Fusion.js supports loading web workers using the [`workerUrl` virtual module](/api/fusion-core#virtual-modules) exposed by `fusion-core`. The virtual module allows Fusion.js to bundle your service worker with Babel.
+
+### Usage
+
+The method signature for `workerUrl` is:
+
+```js
+workerUrl(url: string): string
+```
+
+It takes as input the path to your service worker file and will return the internal Babel-bundled URL. This URL can then be passed to the `Worker` constructor. For example, the following code creates a web worker within a Fusion.js client-side plugin.
+
+```js
+// web-worker-plugin.js
+import {createPlugin, workerUrl} from 'fusion-core';
+
+export default __BROWSER__ && createPlugin({
+  middleware: () => {
+    return (ctx, next) => {
+      const url = workerUrl('./path/to/worker.js');
+      const worker = new Worker(url);
+
+      worker.onmessage = e => {
+        console.log('Worker sent back', e.data);
+      };
+      worker.postMessage('Some message');
+
+      return next();
+    };
+  },
+});
+```
+
+Because the web worker has been transpiled and bundled with Babel, you can also use ES2015+ syntax as well as import other modules within the worker file.
+
+```js
+// worker.js
+
+import add from '../utils/add.js';
+
+class SomeWorkerClass() {
+  // ...
+}
+```
+
+### Restrictions
+
+Since web workers are meant only run on the client, make sure to properly code fence your plugins and worker registration code with `__BROWSER__` guards so the code is not executed on the server.
+
+```js
+// main.js
+
+if (__BROWSER__) {
+  app.register(WebWorkerPlugin);
+}
+```

--- a/documentation/docs/references/web-workers.md
+++ b/documentation/docs/references/web-workers.md
@@ -57,7 +57,7 @@ class SomeWorkerClass() {
 Since web workers are meant only run on the client, make sure to properly code fence your plugins and worker registration code with `__BROWSER__` guards so the code is not executed on the server.
 
 ```js
-// main.js
+// app.js
 
 if (__BROWSER__) {
   app.register(WebWorkerPlugin);

--- a/documentation/docs/references/web-workers.md
+++ b/documentation/docs/references/web-workers.md
@@ -5,9 +5,9 @@ path: /web-workers
 
 # Web workers
 
-A web worker is a mechanism for running background tasks outside of the browser context. Heavy and resource consuming tasks can instead be moved to a background task so as to not block any UI threads in the main window. Communication is done through `postMessage` and `onmessage` handlers on the worker instance.
+A web worker is a mechanism for running background tasks outside of the browser context. Heavy and resource consuming tasks can instead be moved to a background task so as to not block any UI threads in the main window. Communication is done through `postMessage` and `onmessage` handlers in both the worker instance and the browser.
 
-Fusion.js supports loading web workers using the [`workerUrl` virtual module](/api/fusion-core#virtual-modules) exposed by `fusion-core`. The virtual module allows Fusion.js to bundle your service worker with Babel.
+Fusion.js supports loading web workers using the [`workerUrl` virtual module](/api/fusion-core#virtual-modules) exposed by `fusion-core`. The virtual module allows Fusion.js to bundle your web worker with Babel.
 
 ### Usage
 
@@ -17,7 +17,7 @@ The method signature for `workerUrl` is:
 workerUrl(url: string): string
 ```
 
-It takes as input the path to your service worker file and will return the internal Babel-bundled URL. This URL can then be passed to the `Worker` constructor. For example, the following code creates a web worker within a Fusion.js client-side plugin.
+It takes as input the path to your web worker file and will return the internal Babel-bundled URL. This URL can then be passed to the `Worker` constructor. For example, the following code creates a web worker within a Fusion.js client-side plugin.
 
 ```js
 // web-worker-plugin.js

--- a/src/nav-docs.yml
+++ b/src/nav-docs.yml
@@ -79,6 +79,8 @@ children:
         path: '/static-assets'
       - title: 'Configuration'
         path: '/configuration'
+      - title: 'Web workers'
+        path: '/web-workers'
       - title: 'Virtual modules'
         path: '/virtual-modules'
       - title: 'SVG React components'


### PR DESCRIPTION
Adds a section on how to use web workers with Fusion since it's not readily apparent how it is done, other than digging through `fusion-core` API documentation.