### PR TITLE
Fix helmet import missing in tutorial

### DIFF
--- a/documentation/docs/learning-fusionjs-tutorial/building-the-ui.md
+++ b/documentation/docs/learning-fusionjs-tutorial/building-the-ui.md
@@ -121,6 +121,12 @@ export default async function start() {
 }
 ```
 
+Add the import to the top of `src/components/root.js`:
+
+```js
+import {Helmet} from 'fusion-plugin-react-helmet-async';
+```
+
 Then add the following styles in a `<Helmet>` tag to `src/components/root.js` (after the opening `<React.Fragment>` tag):
 
 ```js


### PR DESCRIPTION
The import was missing in the docs so add it.