### PR TITLE
Add index file to docs path

### DIFF
--- a/documentation/docs/index.md
+++ b/documentation/docs/index.md
@@ -1,0 +1,10 @@
+## Docs
+
+- [Overview](/docs/overview)
+  - [Create a New Project](/docs/overview/create-a-new-project)
+  - [Example Projects](/docs/overview/example-projects)
+- [Core Concepts](/docs/core-concepts)
+- [Learning Fusion.js Tutorial](/docs/learning-fusionjs-tutorial)
+- [Recipes](/docs/recipes)
+- [Testing](/docs/testing)
+- [References](/docs/references)


### PR DESCRIPTION
Algolia search is not indexing any of the new content anymore. Looking at the configuration it only indexes starting from `/docs/` which is a broken link right now.

This PR adds an index file that links to all of the other pages in our docs site so that hopefully this lets Algolia index correctly.